### PR TITLE
Rename app to url_fetcher

### DIFF
--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -1,4 +1,4 @@
-# .github/workflows/suggest.yml
+# .github/workflows/advice.yml
 
 name: advice
 on: [pull_request]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# .github/workflows/publish.yml
+
 on:
   push:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-fetcher-*.tar
+url_fetcher-*.tar
 
 # Ignore language server and dialyzer
 .elixir_ls/

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# Fetcher
+# UrlFetcher
 
-![Tests](https://github.com/gorkaio/fetcher/workflows/verify/badge.svg)
+![Tests](https://github.com/gorkaio/url_fetcher/workflows/verify/badge.svg)
 
-_Fetcher_ fetches URLs present in image and anchor tags in a given URL.
+_UrlFetcher_ fetches URLs present in image and anchor tags in a given URL.
 
 ## Usage
 
-### Fetcher
+### UrlFetcher
 
-`Fetcher.fetch("https://myawesome.url/page.html")` will retrieve all link and image URLs present in `https://myawesome.url/page.html`, returning them as lists `links` and `assets` in `Fetcher.SiteData` struct.
+`UrlFetcher.fetch("https://myawesome.url/page.html")` will retrieve all link and image URLs present in `https://myawesome.url/page.html`, returning them as lists `links` and `assets` in `UrlFetcher.SiteData` struct.
 
 Some options you can provide to the fetcher:
 
-- `http_client`: HTTP Client to be used. Must comply with `Fetcher.Http.Client` behaviour. Defaults to `Fetcher.Http.Adapter.Poison`.
+- `http_client`: HTTP Client to be used. Must comply with `UrlFetcher.Http.Client` behaviour. Defaults to `UrlFetcher.Http.Adapter.Poison`.
 - `unique`: boolean. If set, removes duplicates from results. Defaults to `true`.
 - `normalize`: transforms all urls to absolute if set to `:absolute`, or leaves them as they are with `:original`. Defaults to `original`.
 
 ### HTTP Client behaviour
 
-HTTP Client behaviour is defined in `Fetcher.Http.Client`. You can choose whatever HTTP client you prefer as long as it complies with that behavior or you implement a wrapper. Note that, by default, HTTP Client _must_ follow redirects.
+HTTP Client behaviour is defined in `UrlFetcher.Http.Client`. You can choose whatever HTTP client you prefer as long as it complies with that behavior or you implement a wrapper. Note that, by default, HTTP Client _must_ follow redirects.
 
 ## Installation
 
@@ -28,7 +28,7 @@ by adding `url_fetcher` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:fetcher, "~> 0.1.0", hex: :url_fetcher}
+    {:url_fetcher, "~> 0.1.0"}
   ]
 end
 ```

--- a/lib/fetcher/application.ex
+++ b/lib/fetcher/application.ex
@@ -1,4 +1,4 @@
-defmodule Fetcher.Application do
+defmodule UrlFetcher.Application do
   @moduledoc false
 
   use Application
@@ -7,12 +7,12 @@ defmodule Fetcher.Application do
     children =
       case args do
         [env: :prod] -> []
-        [env: :test] -> [{Plug.Cowboy, scheme: :http, plug: Fetcher.Http.MockServer, options: [port: 8081]}]
+        [env: :test] -> [{Plug.Cowboy, scheme: :http, plug: UrlFetcher.Http.MockServer, options: [port: 8081]}]
         [env: :dev] -> []
         [_] -> []
       end
 
-    opts = [strategy: :one_for_one, name: Fetcher.Supervisor]
+    opts = [strategy: :one_for_one, name: UrlFetcher.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/fetcher/http/adapter/httpoison.ex
+++ b/lib/fetcher/http/adapter/httpoison.ex
@@ -1,12 +1,12 @@
-defmodule Fetcher.Http.Adapter.Poison do
+defmodule UrlFetcher.Http.Adapter.Poison do
   @moduledoc """
   HTTPoison adapter for HttpClient behaviour
   """
-  @behaviour Fetcher.Http.Client
+  @behaviour UrlFetcher.Http.Client
 
   @default_opts [follow_redirect: true, max_redirect: 3]
 
-  @spec get(String.t(), key: any) :: {:ok, Fetcher.Http.Client.body()} | {:error, term}
+  @spec get(String.t(), key: any) :: {:ok, UrlFetcher.Http.Client.body()} | {:error, term}
   def get(url, opts \\ []) do
     {headers, opts} = Keyword.pop(opts, :headers, [])
 

--- a/lib/fetcher/http/client.ex
+++ b/lib/fetcher/http/client.ex
@@ -1,4 +1,4 @@
-defmodule Fetcher.Http.Client do
+defmodule UrlFetcher.Http.Client do
   @moduledoc """
   Behaviour adapter for HTTP clients
   """

--- a/lib/fetcher/http/mock_server.ex
+++ b/lib/fetcher/http/mock_server.ex
@@ -1,4 +1,4 @@
-defmodule Fetcher.Http.MockServer do
+defmodule UrlFetcher.Http.MockServer do
   @moduledoc """
   Mock server
 

--- a/lib/fetcher/site_data.ex
+++ b/lib/fetcher/site_data.ex
@@ -1,4 +1,4 @@
-defmodule Fetcher.SiteData do
+defmodule UrlFetcher.SiteData do
   @moduledoc """
   Holds information about parsed site
   """
@@ -16,11 +16,11 @@ defmodule Fetcher.SiteData do
 
   ## Examples
 
-      iex> Fetcher.SiteData.new()
-      %Fetcher.SiteData{links: [], assets: []}
+      iex> UrlFetcher.SiteData.new()
+      %UrlFetcher.SiteData{links: [], assets: []}
 
   """
-  @spec new :: Fetcher.SiteData.t()
+  @spec new :: UrlFetcher.SiteData.t()
   def new do
     %__MODULE__{links: [], assets: []}
   end
@@ -34,12 +34,12 @@ defmodule Fetcher.SiteData do
 
   ## Examples
 
-      iex> Fetcher.SiteData.new()
-      ...>  |> Fetcher.SiteData.with_links(["https://gorka.io"])
-      %Fetcher.SiteData{links: ["https://gorka.io"], assets: []}
+      iex> UrlFetcher.SiteData.new()
+      ...>  |> UrlFetcher.SiteData.with_links(["https://gorka.io"])
+      %UrlFetcher.SiteData{links: ["https://gorka.io"], assets: []}
 
   """
-  @spec with_links(Fetcher.SiteData.t(), list(String.t())) :: Fetcher.SiteData.t()
+  @spec with_links(UrlFetcher.SiteData.t(), list(String.t())) :: UrlFetcher.SiteData.t()
   def with_links(data, links) do
     %__MODULE__{data | links: links}
   end
@@ -53,12 +53,12 @@ defmodule Fetcher.SiteData do
 
   ## Examples
 
-      iex> Fetcher.SiteData.new()
-      ...>  |> Fetcher.SiteData.with_assets(["https://gorka.io/logo.svg"])
-      %Fetcher.SiteData{links: [], assets: ["https://gorka.io/logo.svg"]}
+      iex> UrlFetcher.SiteData.new()
+      ...>  |> UrlFetcher.SiteData.with_assets(["https://gorka.io/logo.svg"])
+      %UrlFetcher.SiteData{links: [], assets: ["https://gorka.io/logo.svg"]}
 
   """
-  @spec with_assets(Fetcher.SiteData.t(), list(String.t())) :: Fetcher.SiteData.t()
+  @spec with_assets(UrlFetcher.SiteData.t(), list(String.t())) :: UrlFetcher.SiteData.t()
   def with_assets(data, assets) do
     %__MODULE__{data | assets: assets}
   end

--- a/lib/url_fetcher.ex
+++ b/lib/url_fetcher.ex
@@ -1,12 +1,12 @@
-defmodule Fetcher do
+defmodule UrlFetcher do
   @moduledoc """
   Fetches asset and link URLs from a given page URL.
   """
-  alias Fetcher.Http.Client, as: HttpClient
-  alias Fetcher.SiteData
+  alias UrlFetcher.Http.Client, as: HttpClient
+  alias UrlFetcher.SiteData
 
   @default_opts [
-    http_client: Fetcher.Http.Adapter.Poison,
+    http_client: UrlFetcher.Http.Adapter.Poison,
     unique: true,
     normalize: :original
   ]
@@ -16,7 +16,7 @@ defmodule Fetcher do
 
   Available options:
 
-    - http_client: HTTP Client to be used. Must comply with `Fetcher.Http.Client` behaviour. Defaults to `Fetcher.Http.Adapter.Poison`.
+    - http_client: HTTP Client to be used. Must comply with `UrlFetcher.Http.Client` behaviour. Defaults to `UrlFetcher.Http.Adapter.Poison`.
     - unique: boolean. If set, removes duplicates from results. Defaults to `true`.
     - normalize: transforms all urls to absolute if set to :absolute, or leaves them as they are with :original. Defaults to `original`.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,20 +4,20 @@ defmodule Fetcher.MixProject do
 
   def project do
     [
-      app: :fetcher,
+      app: :url_fetcher,
       version: "0.1.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 
       # Docs
-      name: "Fetcher",
+      name: "URL Fetcher",
       description: "Fetches link and image URLs from web pages",
-      source_url: "https://github.com/gorkaio/fetcher",
-      homepage_url: "https://github.com/gorkaio/fetcher",
+      source_url: "https://github.com/gorkaio/url_fetcher",
+      homepage_url: "https://github.com/gorkaio/url_fetcher",
       docs: [
         # The main page in the docs
-        main: "Fetcher",
+        main: "URL Fetcher",
         extras: ["README.md"]
       ],
 
@@ -33,7 +33,7 @@ defmodule Fetcher.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: {Fetcher.Application, [env: Mix.env()]},
+      mod: {UrlFetcher.Application, [env: Mix.env()]},
       applications: applications(Mix.env())
     ]
   end
@@ -45,7 +45,7 @@ defmodule Fetcher.MixProject do
     [
       name: "url_fetcher",
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/gorkaio/fetcher"}
+      links: %{"Github" => "https://github.com/gorkaio/url_fetcher"}
     ]
   end
 

--- a/test/url_fetcher/http/adapter/mock_server_test.exs
+++ b/test/url_fetcher/http/adapter/mock_server_test.exs
@@ -1,7 +1,7 @@
-defmodule Fetcher.Http.Adapter.MockServerTest do
+defmodule UrlFetcher.Http.MockServerTest do
   @moduledoc false
   use ExUnit.Case, async: true
-  doctest Fetcher
+  doctest UrlFetcher.Http.MockServer
   alias Plug.Conn.Query
 
   @base_url "http://localhost:8081/"

--- a/test/url_fetcher/site_data_test.exs
+++ b/test/url_fetcher/site_data_test.exs
@@ -1,7 +1,7 @@
-defmodule Fetcher.SiteDataTest do
+defmodule UrlFetcher.SiteDataTest do
   @moduledoc false
   use ExUnit.Case, async: true
-  alias Fetcher.SiteData
+  alias UrlFetcher.SiteData
   doctest SiteData
 
   test "Creates new site data" do

--- a/test/url_fetcher_test.exs
+++ b/test/url_fetcher_test.exs
@@ -1,8 +1,8 @@
-defmodule FetcherTest do
+defmodule UrlFetcherTest do
   @moduledoc false
   use ExUnit.Case, async: true
-  doctest Fetcher
-  alias Fetcher.SiteData
+  doctest UrlFetcher
+  alias UrlFetcher.SiteData
   alias Plug.Conn.Query
 
   @base_url "http://localhost:8081/"
@@ -11,12 +11,12 @@ defmodule FetcherTest do
   @failure_url @base_url <> "failure/"
 
   test "Rejects invalid uls" do
-    assert {:error, :invalid_url} == Fetcher.fetch(5, http_client: Fetcher.Http.Adapter.Poison)
+    assert {:error, :invalid_url} == UrlFetcher.fetch(5, http_client: UrlFetcher.Http.Adapter.Poison)
   end
 
   test "Returns empty lists for pages without links or images" do
     expected = {:ok, SiteData.new()}
-    actual = Fetcher.fetch(@test_url, http_client: Fetcher.Http.Adapter.Poison)
+    actual = UrlFetcher.fetch(@test_url, http_client: UrlFetcher.Http.Adapter.Poison)
 
     assert expected == actual
   end
@@ -33,7 +33,7 @@ defmodule FetcherTest do
       |> URI.to_string()
 
     expected = {:ok, SiteData.new() |> SiteData.with_links(links) |> SiteData.with_assets(assets)}
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison)
 
     assert expected == actual
   end
@@ -69,7 +69,7 @@ defmodule FetcherTest do
          "https://elixirforum.com/uploads/default/original/2X/6/69cdf106f7ad3749056956ca28dc41e6b9b6a145.png"
        ])}
 
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison, normalize: :absolute)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison, normalize: :absolute)
 
     assert expected == actual
   end
@@ -92,7 +92,7 @@ defmodule FetcherTest do
       |> SiteData.with_assets(["https://gorka.io/logo.png"])
     }
 
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison)
 
     assert expected == actual
   end
@@ -115,7 +115,7 @@ defmodule FetcherTest do
       |> SiteData.with_assets(assets)
     }
 
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison, unique: false)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison, unique: false)
 
     assert expected == actual
   end
@@ -138,7 +138,7 @@ defmodule FetcherTest do
       |> URI.to_string()
 
     expected = {:ok, SiteData.new() |> SiteData.with_links(links) |> SiteData.with_assets(assets)}
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison)
 
     assert expected == actual
   end
@@ -152,7 +152,7 @@ defmodule FetcherTest do
       |> Map.put(:query, Query.encode(%{status: 404}))
       |> URI.to_string()
 
-    actual = Fetcher.fetch(url, http_client: Fetcher.Http.Adapter.Poison)
+    actual = UrlFetcher.fetch(url, http_client: UrlFetcher.Http.Adapter.Poison)
 
     assert expected == actual
   end


### PR DESCRIPTION
Conflicting app name already exists in hex.pm. Rename application to `url_fetcher`.